### PR TITLE
feat: add weighted RPS logic based on hero stats

### DIFF
--- a/client/src/__tests__/rpsLogic.test.js
+++ b/client/src/__tests__/rpsLogic.test.js
@@ -1,0 +1,61 @@
+// client/src/__tests__/rpsLogic.test.js
+// Unit tests for decideRPSChoice helper that maps hero stats --> RPS choice
+
+import { describe, test, expect, vi } from "vitest"
+import { decideRPSChoice } from "../utils/rpsLogic"
+
+describe("decideRPSChoice", () => {
+  test("returns 'rock' when strength/durability dominate", () => {
+    const hero = {
+      powerstats: {
+        strength: "100",
+        durability: "90",
+        intelligence: "10",
+        power: "10",
+        speed: "10",
+        combat: "10",
+      },
+    }
+    vi.spyOn(Math, "random").mockReturnValue(0.1) // force into rock range
+    expect(decideRPSChoice(hero)).toBe("rock")
+    Math.random.mockRestore()
+  })
+
+  test("returns 'paper' when intelligence/power dominate", () => {
+    const hero = {
+      powerstats: {
+        intelligence: "95",
+        power: "90",
+        strength: "10",
+        durability: "10",
+        speed: "10",
+        combat: "10",
+      },
+    }
+    vi.spyOn(Math, "random").mockReturnValue(0.4) // force into paper range
+    expect(decideRPSChoice(hero)).toBe("paper")
+    Math.random.mockRestore()
+  })
+
+  test("returns 'scissors' when speed/combat dominate", () => {
+    const hero = {
+      powerstats: {
+        speed: "100",
+        combat: "90",
+        strength: "10",
+        durability: "10",
+        intelligence: "10",
+        power: "10",
+      },
+    }
+    vi.spyOn(Math, "random").mockReturnValue(0.8) // force into scissors range
+    expect(decideRPSChoice(hero)).toBe("scissors")
+    Math.random.mockRestore()
+  })
+
+  test("defaults to equal odds if stats are missing", () => {
+    const hero = { powerstats: {} }
+    const result = decideRPSChoice(hero)
+    expect(["rock", "paper", "scissors"]).toContain(result)
+  })
+})

--- a/client/src/utils/rpsLogic.js
+++ b/client/src/utils/rpsLogic.js
@@ -4,11 +4,25 @@
 export function decideRPSChoice(hero) {
   const stats = hero?.powerstats || {}
 
-  // TODO: Implement weighting logic for Rock, Paper, Scissors
-  // Rock = strength + durability
-  // Paper = intelligence + power
-  // Scissors = speed + combat
+  // Convert values safely to numbers, with a default of 0
+  const strength = Number(stats.strength) || 0
+  const durability = Number(stats.durability) || 0
+  const intelligence = Number(stats.intelligence) || 0
+  const power = Number(stats.power) || 0
+  const speed = Number(stats.speed) || 0
+  const combat = Number(stats.combat) || 0
 
-  // Placeholder (forces failure until implemented)
-  return null
+  // Weight definitions
+  const rockWeight = strength + durability
+  const paperWeight = intelligence + power
+  const scissorsWeight = speed + combat
+
+  const total = rockWeight + paperWeight + scissorsWeight
+  if (total === 0) return "rock" // fallback
+
+  // Random roll across weighted ranges
+  const roll = Math.random() * total
+  if (roll < rockWeight) return "rock"
+  if (roll < rockWeight + paperWeight) return "paper"
+  return "scissors"
 }

--- a/client/src/utils/rpsLogic.js
+++ b/client/src/utils/rpsLogic.js
@@ -1,0 +1,14 @@
+// client/src/utils/rpsLogic.js
+// Decides a hero's Rock/Paper/Scissors choice based on weighted powerstats.
+
+export function decideRPSChoice(hero) {
+  const stats = hero?.powerstats || {}
+
+  // TODO: Implement weighting logic for Rock, Paper, Scissors
+  // Rock = strength + durability
+  // Paper = intelligence + power
+  // Scissors = speed + combat
+
+  // Placeholder (forces failure until implemented)
+  return null
+}

--- a/client/src/utils/rpsLogic.js
+++ b/client/src/utils/rpsLogic.js
@@ -18,7 +18,9 @@ export function decideRPSChoice(hero) {
   const scissorsWeight = speed + combat
 
   const total = rockWeight + paperWeight + scissorsWeight
-  if (total === 0) return "rock" // fallback
+    if (total === 0) {
+        return ["rock", "paper", "scissors"][Math.floor(Math.random() * 3)]
+    } // fallback
 
   // Random roll across weighted ranges
   const roll = Math.random() * total


### PR DESCRIPTION
Implements a new utility `decideRPSChoice` in `rpsLogic.js` that maps hero powerstats to a weighted Rock-Paper-Scissors decision. This adds personality and individuality to each hero’s battle behavior.

## Changes
- Added `client/src/utils/rpsLogic.js`:
  - `decideRPSChoice(hero)` returns "rock", "paper", or "scissors" based on weighted stats
  - Strength + Durability bias → **rock**
  - Intelligence + Power bias → **paper**
  - Speed + Combat bias → **scissors**
- Added `client/src/__tests__/rpsLogic.test.js`:
  - Verifies outcomes for stat-dominant heroes
  - Confirms randomness when stats are missing
  - Uses `Math.random` mocking for deterministic tests

## Next Steps
- Integrate `decideRPSChoice` into the Battle page to determine each hero’s move in a best-of-3 RPS showdown.
- Extend battle logic to evaluate round winners and track score.